### PR TITLE
Watch for errors when baking.

### DIFF
--- a/test/bakery.test.js
+++ b/test/bakery.test.js
@@ -86,6 +86,23 @@ test('bakery.bake: takes a buffer', function (t) {
   })
 });
 
+test('bakery.bake: do not throw on bad image', function (t) {
+  var options = {
+    image: Buffer('pfffffft whatever'),
+    url: ASSERTION_URL,
+  }
+  try {
+    bakery.bake(options, function (err, baked) {
+      t.ok(err, 'should have an error')
+      t.notOk(baked, 'should not have baked data')
+    })
+  } catch(e) {
+    t.fail('should not have thrown')
+  } finally {
+    t.end()
+  }
+});
+
 test('bakery.bake: takes a stream', function (t) {
   var imgStream = getImageStream();
   var options = {


### PR DESCRIPTION
We need to listen for an error event or else it escalates and an
uncatchable error gets thrown. This was happening in the backpack when
someone would try to send in an image that was not a PNG   a signature
error would get emitted, but the `baker.bake` method was not listening
on the `error` event.
