### PR TITLE
[WIP] SVG badges!

### DIFF
--- a/bin/oven
+++ b/bin/oven
@@ -8,11 +8,13 @@ const url = argv._[0];
 const infile = argv.in||argv.infile;
 const outfile = argv.out||argv.outfile;
 const extract = 'extract' in argv;
+const svg = 'svg' in argv;
 
 function log(msg) { process.stderr.write(msg + '\n') }
 function out(data) { process.stdout.write(data) }
 
 function extractData(stream, timer) {
+  var opts = { svg: svg };
   bakery.extract(stream, function done(err, data) {
     timer && timer.clear();
     if (err) {
@@ -21,7 +23,7 @@ function extractData(stream, timer) {
     }
     out(data + '\n');
     process.exit(0);
-  })
+  }, opts);
 }
 
 function bakeImage(stream, timer) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "request": "~2.11.4",
     "streampng": "0.1.6",
-    "optimist": "~0.3.5"
+    "optimist": "~0.3.5",
+    "xml2js": "~0.2.8"
   },
   "devDependencies": {
     "oneshot": "~0.1.0",


### PR DESCRIPTION
How it Works:

The top of a baked SVG badge looks something like this:

``` svg
<?xml version="1.0" encoding="UTF-8"?>
<svg xmlns="http://www.w3.org/2000/svg"
     xmlns:openbadges="http://openbadges.org">
  <openbadges:assertion verify="http://example.org"><![CDATA[{verify:{"url":"http://example.org"}}]]></openbadges:assertion>
```

Note the `openbadges` namespace definition (resolved at http://openbadges.org because of reasons)

The `<openbadges:assertion>` tag has an attribute `verify` which mirrors the URL that would be baked into a hosted-assertion type badge. Additionally, the body of the entire assertion can be placed within the tag as serialized JSON wrapped in <![CDATA[ ]]>.

The code for extraction lives at a logical fork within the `extract` method, and `debake` remains unmodified as a result.

As the code currently stands, if the JSON is present, its `.verify.url` takes precedence over the `verify` attribute (though they should be the same)
- [x] Extracting assertions/ verification URL from SVG files
- [x] Command line flag `--svg`
- [ ] Baking assertions into SVG
- [ ] Testing new badge type
